### PR TITLE
Fix straight flush evaluation bug

### DIFF
--- a/logic-test/test2.swift
+++ b/logic-test/test2.swift
@@ -206,4 +206,34 @@ final class test2: XCTestCase {
         XCTAssertEqual(result.ranks[0], .jack)
         XCTAssertEqual(result.ranks[1], .five)
     }
+
+    // ストレートとフラッシュが別スートで存在する場合はフラッシュ扱いとなるかテスト
+    func testFlushNotStraightFlush() throws {
+        let cards = [
+            Card(rank: .ace, suit: .hearts),
+            Card(rank: .king, suit: .hearts),
+            Card(rank: .queen, suit: .hearts),
+            Card(rank: .jack, suit: .hearts),
+            Card(rank: .ten, suit: .diamonds),
+            Card(rank: .three, suit: .hearts),
+            Card(rank: .two, suit: .clubs)
+        ]
+        let result = PokerHandEvaluator().evaluateHand(cards: cards)
+        XCTAssertEqual(result.rankType, .flush)
+    }
+
+    // 正しいストレートフラッシュ判定のテスト
+    func testStraightFlush() throws {
+        let cards = [
+            Card(rank: .ace, suit: .hearts),
+            Card(rank: .king, suit: .hearts),
+            Card(rank: .queen, suit: .hearts),
+            Card(rank: .jack, suit: .hearts),
+            Card(rank: .ten, suit: .hearts),
+            Card(rank: .two, suit: .clubs),
+            Card(rank: .three, suit: .diamonds)
+        ]
+        let result = PokerHandEvaluator().evaluateHand(cards: cards)
+        XCTAssertEqual(result.rankType, .royalFlush)
+    }
 }

--- a/poker-trainer/Models/PokerHnadEvaluatar.swift
+++ b/poker-trainer/Models/PokerHnadEvaluatar.swift
@@ -182,11 +182,13 @@ class PokerHandEvaluator {
         let isFlush = checkFlush(cards: sortedCards)
         let straightHighCard = checkStraight(cards: sortedCards)
 
-        if isFlush && straightHighCard != nil {
-            if straightHighCard == 14 {
-                return HandRank(rankType: .royalFlush, ranks: sortedCards.map { $0.rank })
+        // ストレートフラッシュ/ロイヤルフラッシュの判定を強化
+        if let sfHighCard = checkStraightFlush(cards: sortedCards) {
+            let ranks = straightRanks(highCard: sfHighCard)
+            if sfHighCard == 14 {
+                return HandRank(rankType: .royalFlush, ranks: ranks)
             } else {
-                return HandRank(rankType: .straightFlush, ranks: sortedCards.map { $0.rank })
+                return HandRank(rankType: .straightFlush, ranks: ranks)
             }
         } else if let fourOfAKindRanks = checkFourOfAKind(cards: sortedCards) {
             return HandRank(rankType: .fourOfAKind, ranks: fourOfAKindRanks)
@@ -331,6 +333,25 @@ class PokerHandEvaluator {
         }
         
         return nil
+    }
+
+    // 特定のスート内でストレートが完成しているか確認
+    private func checkStraightFlush(cards: [Card]) -> Int? {
+        let suitGroups = Dictionary(grouping: cards, by: { $0.suit })
+        for suitCards in suitGroups.values where suitCards.count >= 5 {
+            if let high = checkStraight(cards: suitCards) {
+                return high
+            }
+        }
+        return nil
+    }
+
+    // ストレートの最高カードから5枚のランクを生成
+    private func straightRanks(highCard: Int) -> [Rank] {
+        if highCard == 5 {
+            return [.five, .four, .three, .two, .ace]
+        }
+        return (0..<5).compactMap { Rank(rawValue: highCard - $0) }
     }
 
    private func checkFourOfAKind(cards: [Card]) -> [Rank]? {


### PR DESCRIPTION
## Summary
- fix straight flush detection logic in `PokerHnadEvaluatar.swift`
- add helper functions for straight flush evaluation
- add tests for straight flush and flush cases

## Testing
- `swiftc -emit-library poker-trainer/Models/PokerHnadEvaluatar.swift -o /tmp/libPoker.a`
- `swiftc -emit-library logic-test/test2.swift -o /tmp/libTest.a` *(fails: cannot find XCTest library)*